### PR TITLE
use fabsl with long double arguements

### DIFF
--- a/geometry/util/math/mathutil.cc
+++ b/geometry/util/math/mathutil.cc
@@ -63,7 +63,7 @@ bool MathUtil::RealRootsForCubic(long double const a,
   }
 
   long double const A =
-    -sgn(R) * pow(fabs(R) + sqrt(R_squared - Q_cubed), 1.0/3.0L);
+    -sgn(R) * pow(fabsl(R) + sqrt(R_squared - Q_cubed), 1.0/3.0L);
 
   if (A != 0.0) {  // in which case, B from NR is zero
     *r1 = A + Q / A - a_third;

--- a/geometry/util/math/mathutil.h
+++ b/geometry/util/math/mathutil.h
@@ -106,8 +106,8 @@ class MathUtil {
     // Discriminants below kTolerance in absolute value are considered zero
     // because changing the final bit of one of the inputs can change the
     // sign of the discriminant.
-    const double kTolerance = epsilon * max(fabs(2 * b * b), fabs(4 * a * c));
-    return (fabs(discriminant) <= kTolerance);
+    const long double kTolerance = epsilon * max(fabsl(2 * b * b), fabsl(4 * a * c));
+    return (fabsl(discriminant) <= kTolerance);
   }
 
   // Returns in *r1 and *r2 the roots of a "normal" quadratic equation


### PR DESCRIPTION
prevents compile error:

modules/s2-geometry-library/geometry/util/math/mathutil.h:109:45: error: absolute value function 'fabs' given an argument of type 'long double' but has parameter of type 'double' which may
      cause truncation of value [-Werror,-Wabsolute-value]
    const double kTolerance = epsilon * max(fabs(2 * b * b), fabs(4 * a * c));
                                            ^
modules/s2-geometry-library/geometry/util/math/mathutil.h:109:45: note: use function 'std::abs' instead
    const double kTolerance = epsilon * max(fabs(2 * b * b), fabs(4 * a * c));
                                            ^~~~
                                            std::abs
modules/s2-geometry-library/geometry/util/math/mathutil.h:109:45: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
modules/s2-geometry-library/geometry/util/math/mathutil.h:109:62: error: absolute value function 'fabs' given an argument of type 'long double' but has parameter of type 'double' which may
      cause truncation of value [-Werror,-Wabsolute-value]
    const double kTolerance = epsilon * max(fabs(2 * b * b), fabs(4 * a * c));
                                                             ^
modules/s2-geometry-library/geometry/util/math/mathutil.h:109:62: note: use function 'std::abs' instead
    const double kTolerance = epsilon * max(fabs(2 * b * b), fabs(4 * a * c));
                                                             ^~~~
                                                             std::abs
modules/s2-geometry-library/geometry/util/math/mathutil.h:109:62: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
modules/s2-geometry-library/geometry/util/math/mathutil.h:110:13: error: absolute value function 'fabs' given an argument of type 'long double' but has parameter of type 'double' which may
      cause truncation of value [-Werror,-Wabsolute-value]
    return (fabs(discriminant) <= kTolerance);
            ^