### PR TITLE
COMPILE_ASSERT - add static_assert for C std > 03. attribute unused o…

### DIFF
--- a/geometry/base/casts.h
+++ b/geometry/base/casts.h
@@ -160,7 +160,8 @@ template <class Dest, class Source>
 inline Dest bit_cast(const Source& source) {
   // Compile time assertion: sizeof(Dest) == sizeof(Source)
   // A compile error here means your Dest and Source have different sizes.
-  typedef char VerifySizesAreEqual [sizeof(Dest) == sizeof(Source) ? 1 : -1];
+  typedef char VerifySizesAreEqual [sizeof(Dest) == sizeof(Source) ? 1 : -1]
+                                                     __attribute__((unused));
 
   Dest dest;
   memcpy(&dest, &source, sizeof(dest));

--- a/geometry/base/macros.h
+++ b/geometry/base/macros.h
@@ -43,8 +43,13 @@ template <bool>
 struct CompileAssert {
 };
 
+#if __STDC_VERSION__ >= 200300
+#include <assert.h>
+#define COMPILE_ASSERT(expr, msg) static_assert(expr, msg)
+#else
 #define COMPILE_ASSERT(expr, msg) \
-  typedef CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+  typedef CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1] __attribute__((unused))
+#endif
 
 // Implementation details of COMPILE_ASSERT:
 //


### PR DESCRIPTION
…therwise

While -Wno-unused-local-typedefs was passed it appears clang recognises
-Wno-unused-local-typedef (not plural).

Marking it as unused is a multiple compiler friendly way to do this.

clang compile error:

In file included from modules/s2-geometry-library/geometry/base/basictypes.h:9:
modules/s2-geometry-library/geometry/base/casts.h:89:49: error: unused typedef 'target_type_not_a_reference' [-Werror,-Wunused-local-typedef]
  COMPILE_ASSERT(base::is_reference<To>::value, target_type_not_a_reference);
                                                ^
modules/s2-geometry-library/geometry/base/casts.h:163:16: error: unused typedef 'VerifySizesAreEqual' [-Werror,-Wunused-local-typedef]
  typedef char VerifySizesAreEqual [sizeof(Dest) == sizeof(Source) ? 1 : -1];
               ^
modules/s2-geometry-library/geometry/base/casts.h:280:53: error: unused typedef 'missing_MAKE_ENUM_LIMITS' [-Werror,-Wunused-local-typedef]
  COMPILE_ASSERT(enum_limits<Enum>::is_specialized, missing_MAKE_ENUM_LIMITS);
                                                    ^
modules/s2-geometry-library/geometry/base/casts.h:283:60: error: unused typedef 'unexpected_int_size' [-Werror,-Wunused-local-typedef]
  COMPILE_ASSERT(sizeof(e_val) == 4 || sizeof(e_val) == 8, unexpected_int_size);
                                                           ^
modules/s2-geometry-library/geometry/base/casts.h:334:53: error: unused typedef 'missing_MAKE_ENUM_LIMITS' [-Werror,-Wunused-local-typedef]
  COMPILE_ASSERT(enum_limits<Enum>::is_specialized, missing_MAKE_ENUM_LIMITS);
                                                    ^
modules/s2-geometry-library/geometry/base/casts.h:163:16: error: unused typedef 'VerifySizesAreEqual' [-Werror,-Wunused-local-typedef]
  typedef char VerifySizesAreEqual [sizeof(Dest) == sizeof(Source) ? 1 : -1];
               ^

Signed-off-by: Daniel Black <daniel.black@au.ibm.com>